### PR TITLE
OAuth 1 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ class SocialUserResolver implements SocialUserResolverInterface
      *
      * @return Authenticatable|null
      */
-    public function resolveUserByProviderCredentials(string $provider, string $accessToken): ?Authenticatable
+    public function resolveUserByProviderCredentials(string $provider, string $accessToken, ?string $accessTokenSecret): ?Authenticatable
     {
         // Return the user that corresponds to provided credentials.
         // If the credentials are invalid, then return NULL.

--- a/src/Grants/SocialGrant.php
+++ b/src/Grants/SocialGrant.php
@@ -88,7 +88,7 @@ class SocialGrant extends AbstractGrant
             throw OAuthServerException::invalidRequest('access_token');
         }
 
-        $accessTokenSecret = $this->getRequestParameter('access_token_secret');
+        $accessTokenSecret = $this->getRequestParameter('access_token_secret', $request);
 
         $user = $this->resolver->resolveUserByProviderCredentials($provider, $accessToken, $accessTokenSecret);
         if (is_null($user)) {

--- a/src/Grants/SocialGrant.php
+++ b/src/Grants/SocialGrant.php
@@ -88,7 +88,9 @@ class SocialGrant extends AbstractGrant
             throw OAuthServerException::invalidRequest('access_token');
         }
 
-        $user = $this->resolver->resolveUserByProviderCredentials($provider, $accessToken);
+        $accessTokenSecret = $this->getRequestParameter('access_token_secret');
+
+        $user = $this->resolver->resolveUserByProviderCredentials($provider, $accessToken, $accessTokenSecret);
         if (is_null($user)) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::USER_AUTHENTICATION_FAILED, $request));
             throw OAuthServerException::invalidCredentials();

--- a/src/Resolvers/SocialUserResolverInterface.php
+++ b/src/Resolvers/SocialUserResolverInterface.php
@@ -14,5 +14,5 @@ interface SocialUserResolverInterface
      *
      * @return Authenticatable|null
      */
-    public function resolveUserByProviderCredentials(string $provider, string $accessToken): ?Authenticatable;
+    public function resolveUserByProviderCredentials(string $provider, string $accessToken, ?string $accessTokenSecret): ?Authenticatable;
 }


### PR DESCRIPTION
Fixes #7 by adding an optional `access_token_secret` parameter to requests.