### PR TITLE
Allow passport v9.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "laravel/passport": "^6.0|^7.0|^8.0"
+        "laravel/passport": "^6.0|^7.0|^8.0|^9.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.1",


### PR DESCRIPTION
Hi, @hivokas 

Passport version 9 has been tagged.

Please tag a new version after merging the PR.

Thanks.