### PR TITLE
Integrating GeneaLabs/laravel-sign-in-with-apple

### DIFF
--- a/src/Grants/SocialGrant.php
+++ b/src/Grants/SocialGrant.php
@@ -83,7 +83,7 @@ class SocialGrant extends AbstractGrant
             throw OAuthServerException::invalidRequest('provider');
         }
 
-        $accessToken = $this->getRequestParameter('access_token', $request);
+        $accessToken = $this->getRequestParameter('id_token', $request) ?? $this->getRequestParameter('access_token', $request);
         if (is_null($accessToken)) {
             throw OAuthServerException::invalidRequest('access_token');
         }


### PR DESCRIPTION
Integrating

https://github.com/GeneaLabs/laravel-sign-in-with-apple

into Laravel Project, but Apple is not using the *access token* `access_token` to validate user, but is using *id token* `id_token` to validate user. This change should replace $accessToken with `id_token` when the request parameter is present else return `access_token` request parameter.