### PR TITLE
[3.0] Drop support for older versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - dev
+      - next
   pull_request:
   schedule:
     - cron: '0 0 1 * *'
@@ -16,7 +17,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4]
+        php: [7.2, 7.3, 7.4]
         composer-flag: [prefer-lowest, prefer-stable]
 
     name: php v${{ matrix.php }} - ${{ matrix.composer-flag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-All notable changes to `laravel-passport-social-grant` will be documented in this file
+All notable changes to `laravel-passport-social-grant` will be documented in this file:
+
+## 3.0.0
+* Drop support for Passport v6.x and v7.x
+* Bump min php version to 7.2
 
 ## 1.0.0
 - Initial release

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
-        "laravel/passport": "^6.0|^7.0|^8.0|^9.0"
+        "php": "^7.2",
+        "laravel/passport": "^8.0||^9.0"
     },
     "require-dev": {
-        "mockery/mockery": "^1.1",
-        "orchestra/testbench": "~3.0"
+        "mockery/mockery": "^1.3",
+        "orchestra/testbench": "^5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
* Drop support for `laravel/passport` v6 and v7.
* Support for last 2 passport version only (8 and 9 as of now)
* Bump min php version to 7.2

/cc @hivokas 