### PR TITLE
Fix for '*' scope not being set for issued tokens

### DIFF
--- a/src/Grants/SocialGrant.php
+++ b/src/Grants/SocialGrant.php
@@ -50,7 +50,7 @@ class SocialGrant extends AbstractGrant
         $user = $this->validateUser($request);
 
         // Finalize the requested scopes
-        $finalizedScopes = $this->scopeRepository->finalizeScopes($scopes, $this->getIdentifier(), $client, $user->getIdentifier());
+        $finalizedScopes = $this->scopeRepository->finalizeScopes($scopes, 'password', $client, $user->getIdentifier());
 
         // Issue and persist new tokens
         $accessToken = $this->issueAccessToken($accessTokenTTL, $client, $user->getIdentifier(), $finalizedScopes);


### PR DESCRIPTION
Hi,

Global '*' scope is not set when issuing tokens, because the social grant is not a valid grantType in  `Laravel\Passport\Bridge\ScopeRepository`, the `finalizeScopes` function:
https://github.com/laravel/passport/blob/63c8b6645b2503af10ae3f64938c12b2790ac753/src/Bridge/ScopeRepository.php#L24
```php
public function finalizeScopes(
        array $scopes, $grantType,
        ClientEntityInterface $clientEntity, $userIdentifier = null)
    {
        if (! in_array($grantType, ['password', 'personal_access', 'client_credentials'])) {
            $scopes = collect($scopes)->reject(function ($scope) {
                return trim($scope->getIdentifier()) === '*';
            })->values()->all();
        }
    ...
    }
```

With this proposed change, we can simply finalizeScopes as for the 'password' grant, since social grant is based on it anyway.

Maybe fixes #20 where [default scope](https://laravel.com/docs/7.x/passport#default-scope) is not being set on tokens
