### PR TITLE
Add support for Laravel 11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - dev
-      - next
   pull_request:
   schedule:
     - cron: '0 0 1 * *'
@@ -18,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ 8.1, 8.2 ]
+        php: [ 8.2, 8.3 ]
         laravel: [ 10, 11 ]
 
     name: PHP ${{ matrix.php }} - Laravel v${{ matrix.laravel }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [ 8.1, 8.2 ]
-        laravel: [ 9, 10 ]
+        laravel: [ 10, 11 ]
 
     name: PHP ${{ matrix.php }} - Laravel v${{ matrix.laravel }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this package will be documented in this file:
 ## 3.2.0
 
 * Add support for Laravel 11
-* Test on Laravel 11 and drop testing on Laravel 9
+* Drop support for Laravel 9
 
 ## 3.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this package will be documented in this file:
 
+## 3.2.0
+
+* Add support for Laravel 11
+* Test on Laravel 11 and drop testing on Laravel 9
+
 ## 3.1.0
 
 * Drop php 8.0 support

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Ilya Sakovich
+Copyright (c) 2024 Ilya Sakovich
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The package will automatically register itself.
 
 As the first step, you need to implement `SocialUserResolverInterface`:
 
-Here is an example using [Socialite](https://laravel.com/docs/9.x/socialite) -
+Here is an example using [Socialite](https://laravel.com/docs/11.x/socialite) -
 
 ```php
 <?php

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
     }
   ],
   "require": {
-    "php": "^8.1",
+    "php": "^8.2",
     "laravel/passport": "^11.3.0 || ^12.0"
   },
   "require-dev": {
     "mockery/mockery": "^1.4.4",
-    "orchestra/testbench": "^7.13.0 || ^8.0",
+    "orchestra/testbench": "^8.0 || ^9.0",
     "laminas/laminas-diactoros": "^2.8",
-    "phpunit/phpunit": "^9.5"
+    "phpunit/phpunit": "^9.5 || ^10.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   ],
   "require": {
     "php": "^8.1",
-    "laravel/passport": "^11.3.0"
+    "laravel/passport": "^11.3.0 || ^12.0"
   },
   "require-dev": {
     "mockery/mockery": "^1.4.4",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,7 +16,7 @@
     </coverage>
     <testsuites>
         <testsuite name="Test Suite">
-            <directory suffix=".php">./tests</directory>
+            <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
This PR adds support for Laravel 11 by allowing `laravel/passport ^12.0`
Automated tests also have been updated to test against Laravel 11 
 and drop testing for Laravel 9 (end of life)