### PR TITLE
Support for passport 13.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   ],
   "require": {
     "php": "^8.2",
-    "laravel/passport": "^11.3.0 || ^12.0"
+    "laravel/passport": "^13.0"
   },
   "require-dev": {
     "mockery/mockery": "^1.4.4",
@@ -48,7 +48,10 @@
     }
   },
   "config": {
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "php-http/discovery": true
+    }
   },
   "minimum-stability": "dev",
   "prefer-stable": true

--- a/src/Providers/SocialGrantServiceProvider.php
+++ b/src/Providers/SocialGrantServiceProvider.php
@@ -23,13 +23,17 @@ class SocialGrantServiceProvider extends ServiceProvider
 
     protected function makeSocialGrant(): SocialGrant
     {
-        $grant = new SocialGrant(
+        return tap($this->buildSocialGrant(), function (SocialGrant $grant) {
+            $grant->setRefreshTokeNTTL(Passport::refreshTokensExpireIn());
+            $grant->setDefaultScope(Passport::$defaultScope);
+        });
+    }
+
+    protected function buildSocialGrant(): SocialGrant
+    {
+        return new SocialGrant(
             $this->app->make(SocialUserResolverInterface::class),
-            $this->app->make(RefreshTokenRepository::class)
+            $this->app->make(RefreshTokenRepository::class),
         );
-
-        $grant->setRefreshTokenTTL(Passport::refreshTokensExpireIn());
-
-        return $grant;
     }
 }

--- a/tests/SocialGrantTest.php
+++ b/tests/SocialGrantTest.php
@@ -43,8 +43,9 @@ class SocialGrantTest extends AbstractTestCase
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
-        $refreshTokenEntity = new AccessTokenEntity();
-        $accessTokenRepositoryMock->method('getNewToken')->willReturn($refreshTokenEntity);
+        $accessTokenEntity = new AccessTokenEntity();
+        $accessTokenEntity->setClient($client);
+        $accessTokenRepositoryMock->method('getNewToken')->willReturn($accessTokenEntity);
         $accessTokenRepositoryMock->method('persistNewAccessToken')->willReturnSelf();
 
         $socialUserResolverMock = $this->getMockBuilder(SocialUserResolverInterface::class)->getMock();
@@ -99,9 +100,16 @@ class SocialGrantTest extends AbstractTestCase
 
         $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
 
+        $scope = new ScopeEntity();
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn($scope);
+        $scopeRepositoryMock->method('finalizeScopes')->willReturnArgument(0);
+
         $grant = new SocialGrant($socialUserResolverMock, $refreshTokenRepositoryMock);
         $grant->setClientRepository($clientRepositoryMock);
         $grant->setAccessTokenRepository($accessTokenRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
+        $grant->setDefaultScope(self::DEFAULT_SCOPE);
 
         $serverRequest = new ServerRequest();
         $serverRequest = $serverRequest->withParsedBody(
@@ -113,6 +121,11 @@ class SocialGrantTest extends AbstractTestCase
         );
 
         $responseType = new ResponseType();
+
+        $this->expectException(OAuthServerException::class);
+        $this->expectExceptionCode(3);
+
+
         $grant->respondToAccessTokenRequest($serverRequest, $responseType, new \DateInterval('PT5M'));
     }
 
@@ -130,9 +143,16 @@ class SocialGrantTest extends AbstractTestCase
 
         $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
 
+        $scope = new ScopeEntity();
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn($scope);
+        $scopeRepositoryMock->method('finalizeScopes')->willReturnArgument(0);
+
         $grant = new SocialGrant($socialUserResolverMock, $refreshTokenRepositoryMock);
         $grant->setClientRepository($clientRepositoryMock);
         $grant->setAccessTokenRepository($accessTokenRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
+        $grant->setDefaultScope(self::DEFAULT_SCOPE);
 
         $serverRequest = new ServerRequest();
         $serverRequest = $serverRequest->withParsedBody(
@@ -144,6 +164,11 @@ class SocialGrantTest extends AbstractTestCase
         );
 
         $responseType = new ResponseType();
+
+        $this->expectException(OAuthServerException::class);
+        $this->expectExceptionCode(3);
+
+
         $grant->respondToAccessTokenRequest($serverRequest, $responseType, new \DateInterval('PT5M'));
     }
 
@@ -163,9 +188,16 @@ class SocialGrantTest extends AbstractTestCase
 
         $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
 
+        $scope = new ScopeEntity();
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn($scope);
+        $scopeRepositoryMock->method('finalizeScopes')->willReturnArgument(0);
+
         $grant = new SocialGrant($socialUserResolverMock, $refreshTokenRepositoryMock);
         $grant->setClientRepository($clientRepositoryMock);
         $grant->setAccessTokenRepository($accessTokenRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
+        $grant->setDefaultScope(self::DEFAULT_SCOPE);
 
         $serverRequest = new ServerRequest();
         $serverRequest = $serverRequest->withParsedBody(
@@ -178,6 +210,10 @@ class SocialGrantTest extends AbstractTestCase
         );
 
         $responseType = new ResponseType();
+
+        $this->expectException(OAuthServerException::class);
+        $this->expectExceptionCode(6);
+
         $grant->respondToAccessTokenRequest($serverRequest, $responseType, new \DateInterval('PT5M'));
     }
 }

--- a/tests/Stubs/ResponseType.php
+++ b/tests/Stubs/ResponseType.php
@@ -2,7 +2,7 @@
 
 namespace Coderello\SocialGrant\Tests\Stubs;
 
-use Zend\Diactoros\Response;
+use Laminas\Diactoros\Response;
 use Psr\Http\Message\ResponseInterface;
 use League\OAuth2\Server\ResponseTypes\AbstractResponseType;
 
@@ -18,7 +18,7 @@ class ResponseType extends AbstractResponseType
         return $this->refreshToken;
     }
 
-    public function generateHttpResponse(ResponseInterface $response)
+    public function generateHttpResponse(ResponseInterface $response): ResponseInterface
     {
         return new Response();
     }


### PR DESCRIPTION
This PR adds support for `laravel/passport: ^13.x`

I also included some small refactors of the code. These were not necessary to make this upgrade work, so let me know if I should create a separate PR for these or if you are not interested in them.